### PR TITLE
Add 'low_vram' flag to optimize VRAM usage in rb-modulation.ipynb and fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd ..
 # Install dependencies following the original [StableCascade](https://github.com/Stability-AI/StableCascade/blob/master/inference/readme.md)
 conda create -n rbm python==3.9
 pip install -r requirements.txt
-pip install jupyter notebook opencv-python matplotlib ffty
+pip install jupyter notebook opencv-python matplotlib ftfy
 
 # Download [pre-trained CSD weights](https://drive.google.com/file/d/1FX0xs8p-C7Ob-h5Y4cUhTeOepHzXv_46/view) and put it under `third_party/CSD/checkpoint.pth`.
 


### PR DESCRIPTION
Thanks for the research and code sharing.
I’m submitting a PR to help the notebook run on GPUs with lower VRAM.


### Changes:
1. **Add 'low_vram' flag to rb-modulation.ipynb:**
   - Introduce flag to optimize the notebook for systems with 24GB of VRAM.
   - Approaches:
      - Offload `models.generator` to CPU during the plugin RB-modulation stage
      - Offload all modules except `generator` and `previewer` during the VRAM-intensive sampling stage

2. **(Minor) Fix typo in `README.md`:**
   - Correct `ffty` to `ftfy`.

### Benefits:
- Improved compatibility of the notebook on systems with lower VRAM.
- Enhanced documentation accuracy.

### Disclaimer:
- Setting `low_vram` to `True` resolves out-of-memory (OOM) issues and ensures stable operation on GPUs like the RTX 4090, which have 24GB of VRAM.
- For GPUs with less than 24GB of VRAM, an advanced offloading strategy will be required.

Please review the changes and let me know if any further adjustments are needed.